### PR TITLE
Efficient coordinate extraction

### DIFF
--- a/calc_props.py
+++ b/calc_props.py
@@ -337,9 +337,10 @@ def get_atom_coords(mol, heavy_only = False):
     """
     num_atoms = len(mol.atoms)
     pts = np.empty(shape = (num_atoms,3))
+    atoms = mol.atoms
 
     for a in range(num_atoms):
-        pts[a] = mol.atoms[a].coords
+        pts[a] = atoms[a].coords
 
     return pts
 

--- a/calc_props.py
+++ b/calc_props.py
@@ -140,8 +140,9 @@ def average_properties(mol):
         mols.SetConformer(i)
         pymol = pybel.Molecule(mols)
         # calculate properties
-        globs[i] = calc_glob(pymol)
-        pbfs[i] = calc_pbf(pymol)
+        points = get_atom_coords(pymol)
+        globs[i] = calc_glob(points)
+        pbfs[i] = calc_pbf(points)
 
     data = {
         'formula': pymol.formula,
@@ -219,19 +220,18 @@ def run_confab(mol, rmsd_cutoff=0.5, conf_cutoff=100000, energy_cutoff=50.0, con
 
     return mol
 
-def calc_glob(mol):
+def calc_glob(points):
     """
     Calculates the globularity (glob) of a molecule
 
     glob varies from 0 to 1 with completely flat molecules like benzene having a
     glob of 0 and spherical molecules like adamantane having a glob of 1
 
-    :param mol: pybel molecule object
-    :type mol: pybel.Molecule
+    :param points: numpy array of atom coordinates
+    :type points: numpy array
     :return: globularity of molecule
     :rtype: float | int
     """
-    points = get_atom_coords(mol, heavy_only = False)
     if points is None:
         return 0
     points = points.T
@@ -250,17 +250,16 @@ def calc_glob(mol):
         return -1
 
 
-def calc_pbf(mol):
+def calc_pbf(points):
     """
     Uses SVD to fit atoms in molecule to a plane then calculates the average
     distance to that plane.
 
-    :param mol: pybel molecule object
-    :type mol: pybel.Molecule
+    :param points: numpy array of atom coordinates
+    :type points: numpy array
     :return: average distance of all atoms to the best fit plane
     :rtype: float
     """
-    points = get_atom_coords(mol)
     c, n = svd_fit(points)
     pbf = calc_avg_dist(points, c, n)
     return pbf
@@ -328,7 +327,7 @@ def calc_avg_dist(points, C, N):
         sum += abs(distance(xyz, C, N))
     return sum / len(points)
 
-def get_atom_coords(mol, heavy_only = False):
+def get_atom_coords(mol):
     """
     Retrieve the 3D coordinates of all atoms in a molecules
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -117,7 +117,8 @@ def test_pbf():
     obConv.SetInFormat("mol")
     obConv.ReadFile(obmol, os.path.join(THIS_DIR, "data/triphenylphosphine.mol"))
     pymol = pybel.Molecule(obmol)
-    assert_almost_equal(calc_props.calc_pbf(pymol), 1.0072297, 6, 1)
+    points = calc_props.get_atom_coords(pymol)
+    assert_almost_equal(calc_props.calc_pbf(points), 1.0072297, 6, 1)
 
 def test_glob():
     obmol = openbabel.OBMol()
@@ -125,7 +126,8 @@ def test_glob():
     obConv.SetInFormat("mol")
     obConv.ReadFile(obmol, os.path.join(THIS_DIR, "data/triphenylphosphine.mol"))
     pymol = pybel.Molecule(obmol)
-    assert_almost_equal(calc_props.calc_glob(pymol), 0.245503, 6, 1)
+    points = calc_props.get_atom_coords(pymol)
+    assert_almost_equal(calc_props.calc_glob(points), 0.245503, 6, 1)
 
 def test_glob_benzene():
     mol = calc_props.smiles_to_ob("c1ccccc1")


### PR DESCRIPTION
Thank you for the great code! I've been using it recently and it's been working very smoothly. However, as I was looking through the code, I did notice two sources of inefficiency that could be improved.

First, in the function `get_atom_coords`, which is used by both `calc_glob` and `calc_pbf`, the atom coordinates are extracted using the following for loop:

```python
for a in range(num_atoms):
    pts[a] = mol.atoms[a].coords
```

If `mol.atoms` was a list, this would be perfectly fine since it would simply index into the list for each atom. However, mol.atoms is actually a property of a pybel `Molecule` defined as follows:

```python
@property
def atoms(self):
    return [Atom(self.OBMol.GetAtom(i + 1))
            for i in range(self.OBMol.NumAtoms())]
```

This means that `mol.atoms[a].coords` actually recomputes the entire `mol.atoms` list every time it is called rather than indexing into the list.

A very easy fix, which I implemented, is to compute and extract the list first and then index into that list, as seen below.

```python
atoms = mol.atoms  # computes the atoms list and saves it

for a in range(num_atoms):
    pts[a] = atoms[a].coords  # indexes into the saved atoms list
```

This fix reduces the time to compute properties of the `tests/data/b-lactams.smi` molecules from ~15 seconds to ~8.5 seconds.

Second, I noticed that both `calc_glob` and `calc_pbf` both only require the atom coordinates and don't actually need the pybel `Molecule` object itself. Therefore, in order to avoid extracting the atom coordinates twice, I moved the calls to `get_atom_coords` from inside `calc_glob` and `calc_pbf` to outside those functions, and then I give those two functions the points rather than the `Molecule` object.

So the code goes from

```python
def average_properties(mol):
    ...
    pymol = pybel.Molecule(mols)
    globs[i] = calc_glob(pymol)
    pbfs[i] = calc_pbf(pymol)
    ...

def calc_glob(mol):
    points = get_atom_coords(mol)
    ...  # only depends on points, not on mol

def calc_pbf(mol):
    points = get_atom_coords(mol)
    ...  # only depends on points, not on mol
```

to

```python
def average_properties(mol):
    ...
    pymol = pybel.Molecule(mols)
    points = get_atom_coords(pymol)
    globs[i] = calc_glob(points)
    pbfs[i] = calc_pbf(points)
    ...

def calc_glob(points):
    ...  # only depends on points, not on mol

def calc_pbf(points):
    ...  # only depends on points, not on mol
```

This further reduces the time from ~8.5 seconds to ~8.1 seconds.

I hope these improvements are helpful!