### PR TITLE
Upgrade to OpenBabel 3.1.1

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           update-conda: true
           python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge, openbabel, rdkit
+          conda-channels: anaconda, conda-forge, rdkit
       - name: Install dependencies
         run: |
           conda --version

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: [2.7, 3.6, 3.7]
+        python-version: [3.6, 3.7]
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 conda update
 conda create -n entry-cli-env python=3.6 numpy -y
-conda install -c rdkit rdkit=2018.09.1.0 -y
+conda install -c rdkit rdkit=2019.03.4.0 -y
 conda install -c openbabel openbabel=3.1.1 -y
 conda activate entry-cli-env
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 conda update
 conda create -n entry-cli-env python=3.6 numpy -y
 conda install -c rdkit rdkit=2018.09.1.0 -y
-conda install -c openbabel openbabel=2.4.1 -y
+conda install -c openbabel openbabel=3.1.1 -y
 conda activate entry-cli-env
 ```
 

--- a/calc_props.py
+++ b/calc_props.py
@@ -3,8 +3,8 @@ import argparse
 import os
 import sys
 import csv
-import openbabel as ob
-import pybel
+from openbabel import openbabel as ob
+from openbabel import pybel
 import numpy as np
 from rdkit import Chem
 from rdkit.Chem import AllChem
@@ -324,7 +324,7 @@ def is_rotor(bond, include_amides=False):
     :rtype: bool
     """
     # Must be single or triple bond
-    if bond.IsDouble(): return False
+    if bond.GetBondOrder() == 2: return False
 
     # Don't count the N-C bond of amides
     if bond.IsAmide() and not include_amides: return False
@@ -336,7 +336,7 @@ def is_rotor(bond, include_amides=False):
     if (bond.GetBeginAtom().GetHyb() == 1) != (bond.GetEndAtom().GetHyb() == 1): return False
 
     # Cannot be terminal
-    if bond.GetBeginAtom().GetHvyValence() > 1 and bond.GetEndAtom().GetHvyValence() > 1: return True
+    if bond.GetBeginAtom().GetHvyDegree() > 1 and bond.GetEndAtom().GetHvyDegree() > 1: return True
 
 
 def calc_avg_dist(points, C, N):

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,4 @@ dependencies:
 - numpy
 - nose
 - openbabel=3.1.1
-- rdkit=2018.09.1.0
+- rdkit=2019.03.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: entry-cli-env
 channels:
-  - openbabel
   - rdkit
   - conda-forge
   - defaults
@@ -8,5 +7,5 @@ dependencies:
 - python
 - numpy
 - nose
-- openbabel=2.4.1
+- openbabel=3.1.1
 - rdkit=2018.09.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 nose
 numpy
 openbabel=3.1.1
-rdkit=2018.09.1.0
+rdkit=2019.03.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # $ conda create --name <env> --file <this file>
 nose
 numpy
-openbabel=2.4.1
+openbabel=3.1.1
 rdkit=2018.09.1.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 from nose.tools import *
-import openbabel
+from openbabel import openbabel
 import os
 from .context import calc_props
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,6 +1,6 @@
 from nose.tools import *
-import openbabel
-import pybel
+from openbabel import openbabel
+from openbabel import pybel
 import os
 from .context import calc_props
 


### PR DESCRIPTION
This pull request upgrades the dependency on OpenBabel to the latest version (note that recent versions of OpenBabel are in the conda-forge channel).
I've also updated the RDKit dependency to 2019.03.4. Note that from RDKit 2019.09.1 onwards, there are some changes to the atomic van der Waals radii used for calculating conformations. This results in differences in the calculated globularity values, hence I have stopped at 2019.03.4 to ensure stability of the calculated values. 
**Note: The RDKit dependency removes support for Python 2.7 - I have removed this from the CI build matrix.**
Fixes #11 
